### PR TITLE
fix(types): change error type to unknown

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -22,7 +22,7 @@ export interface ReadyMessage {
 export interface ResponseMessage {
   taskId: number
   result: any
-  error: Error | null
+  error: unknown | null
 }
 
 // Internal symbol used to mark Transferable objects returned

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,7 +285,7 @@ class TaskInfo extends AsyncResource implements Task {
     return ret
   }
 
-  done(err: Error | null, result?: any): void {
+  done(err: unknown | null, result?: any): void {
     this.emitDestroy() // `TaskInfo`s are used only once.
     this.runInAsyncScope(this.callback, null, err, result)
     // If an abort signal was used, remove the listener from it when


### PR DESCRIPTION
In TS 4.4 or 4.5, they change the `catch (e: unknown)` from `Error` to `unknown` as throwing a none `Error` is also valid in JS.

This PR makes the typechecker stop complaining about the error.